### PR TITLE
Fix the explanation for the converse of  ⊎×-implies-×⊎

### DIFF
--- a/plfa/part1/Connectives.agda
+++ b/plfa/part1/Connectives.agda
@@ -299,6 +299,6 @@ currying =
 ⊎×-implies-×⊎ (inj₁ ⟨ x , y ⟩) = ⟨ (inj₁ x) , (inj₁ y) ⟩
 ⊎×-implies-×⊎ (inj₂ ⟨ z , α ⟩) = ⟨ (inj₂ z) , (inj₂ α) ⟩
 
--- The converse doesn't hold because we can have B = D = ⊥. This would give us
--- (A ⊎ C) × (⊥ ⊎ ⊥) → (A × ⊥) ⊎ (C × ⊥), and the lhs of the implication is not
+-- The converse doesn't hold because we can have B = C = ⊥. This would give us
+-- (A ⊎ ⊥) × (⊥ ⊎ D) → (A × ⊥) ⊎ (⊥ × D), and the lhs of the implication is not
 -- empty, whereas the rhs is.


### PR DESCRIPTION
I think that with the example given now, both the RHS and LHS will be non empty. Please do let me know I have it wrong.